### PR TITLE
feat: add Set Stream Profile action

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ For more information, please refer to the [Companion documentation](https://gith
 	- Control switching mode.
 - **System Commands**
 	- Perform system actions, including shutdown and reboot
+- **Set Stream Profile**
+	- Select which stream profile is active on the device.
 
 ### Feedbacks
 All feedbacks are booleans, which allows them to be used in triggers.

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -42,6 +42,8 @@ This module can be used to communicate with a RØDECaster Video switcher.
 	- Control switching mode.
 - **System Commands**
 	- Perform system actions, including shutdown and reboot
+- **Set Stream Profile**
+	- Select which stream profile is active on the device.
 
 ### Feedbacks
 All feedbacks are booleans, which allows them to be used in triggers.

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -76,6 +76,7 @@ export enum ActionId {
 	setInput = 'setInput',
 	switching_mode = 'switching_mode',
 	system = 'system',
+	stream_profile = 'stream_profile',
 }
 
 export function UpdateActions(instance: RCVInstance): void {
@@ -2720,6 +2721,46 @@ export function UpdateActions(instance: RCVInstance): void {
 					const type = 'shutdown';
 					delete instance.actions[feedback.id];
 					ConsoleLog(instance, `Removing button id ${feedback.id} of type ${type}`, LogLevel.DEBUG, false);
+				}
+			},
+		},
+		[ActionId.stream_profile]: {
+			name: 'Set Stream Profile',
+			description: 'Select which stream profile is active on the RCV',
+			options: [
+				{
+					id: 'profile',
+					type: 'number',
+					label: 'Profile Number',
+					min: 1,
+					max: 10,
+					default: 1,
+					step: 1,
+					range: false,
+					required: true,
+				},
+				{
+					id: 'total',
+					type: 'number',
+					label: 'Total Number of Profiles',
+					min: 1,
+					max: 10,
+					default: 2,
+					step: 1,
+					range: false,
+					required: true,
+				},
+			],
+			callback: async (ev) => {
+				const selected = ev.options.profile as number;
+				const total = ev.options.total as number;
+
+				for (let i = 1; i <= total; i++) {
+					await sendOSCCommand(
+						instance,
+						`/show/stream/${i}/enabled`,
+						i === selected ? 'true' : 'false'
+					);
 				}
 			},
 		},


### PR DESCRIPTION
## Summary
Adds a new **Set Stream Profile** action for the RØDECaster Video.

I needed a way to switch between stream profiles from Companion during live shows. This action sends `/show/stream/{i}/enabled` OSC commands to activate one profile and disable the others.

### Options
- **Profile Number** (1-10): which profile to activate
- - **Total Number of Profiles** (1-10): how many profiles are configured
## Transparency note
I'm not a developer - I built this with help from Claude (AI assistant) and tested it on my own RØDECaster Video S. Happy to take feedback and make changes if anything needs adjusting.

## Test plan
- Tested stream profile switching on a physical RØDECaster Video S
- - Built and verified no TypeScript errors
- - Updated README.md and HELP.md with the new action